### PR TITLE
Preview receives JSON messages from trusted origin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ VITE_COMM_API_EDIT_ENDPOINT_URL=http://localhost:3000/edit
 VITE_COMM_API_SAVEDATA_ICM_ENDPOINT_URL=http://localhost:3000/saveICMData
 VITE_COMM_API_LOADDATA_ICM_ENDPOINT_URL=http://localhost:3000/loadICMData
 VITE_COMM_API_UNLOCK_ICM_FORM_URL=http://localhost:3000/clearICMLockedFlag
+
+VITE_TEMPLATE_REPO_URL=http://localhost:3000
+VITE_KLAMM_URL=http://localhost:8000


### PR DESCRIPTION
## What changes did you make?

Added the ability to parse JSON messages to the Kiln preview endpoint.

## Why did you make these changes?

Allows Template Repository and Klamm to send JSON messages to the text area directly and preview the form.

## What alternatives did you consider?

None.

### Checklist

- [X] **I have assigned at least one reviewer**
- [X] **My code meets the style guide**
- [X] **My code has adequate test coverage (if applicable)**
