### PR TITLE
Force recreated pods to pull latest image

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       containers:
         - name: kiln
           image: "{{ .Values.image.tag }}"
+          imagePullPolicy: Always
           ports:
             - containerPort: 8080
           resources: {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
## What changes did you make?

Set the pull policy for the deployment

## Why did you make these changes?

Have the app pull the latest tagged image when recreating/deploying the app.

## What alternatives did you consider?

None.

### Checklist

- [X] **I have assigned at least one reviewer**
- [X] **My code meets the style guide**
- [X] **My code has adequate test coverage (if applicable)**
