### PR TITLE
Refactor group Id generation and text input

### DIFF
--- a/src/Renderer.tsx
+++ b/src/Renderer.tsx
@@ -237,6 +237,8 @@ const Renderer: React.FC<RendererProps> = ({ data, mode, goBack }) => {
             item.groupItems?.map((groupItem, groupIndex) => {
               const groupState: { [key: string]: string } = {};
               groupItem.fields.forEach((field) => {
+                // Save the original ID for later
+                ;(field as any).templateId = field.id;
                 const fieldId = generateUniqueId(item.id, groupIndex, field.id);
                 field.id = fieldId;
                 groupState[field.id] = "";
@@ -357,11 +359,9 @@ const Renderer: React.FC<RendererProps> = ({ data, mode, goBack }) => {
         // Create a deep copy of the first group item and modify its IDs
         const newGroupItem = JSON.parse(JSON.stringify(group.groupItems[0]));
         newGroupItem.fields.forEach((field: Item) => {
-          const newFieldId = generateUniqueId(
-            groupId,
-            groupIndex,
-            field.id.split("-").slice(2).join("-")
-          );
+          // pull back the original templateId
+          const templateld = (field as any).templateId as string;
+          const newFieldId = generateUniqueId(groupId, groupIndex, templateld);
           field.id = newFieldId;
         });
         group.groupItems.push(newGroupItem);
@@ -378,13 +378,10 @@ const Renderer: React.FC<RendererProps> = ({ data, mode, goBack }) => {
       const firstGroupItem = group?.groupItems?.[0];
 
       firstGroupItem?.fields.forEach((field: Item) => {
-        const newFieldId = generateUniqueId(
-          groupId,
-          groupIndex,
-          field.id.split("-").slice(2).join("-")
-        );
-        newGroupItemState[newFieldId] =
-          initialData && initialData[newFieldId] ? initialData[newFieldId] : ""; // Use initialData if available
+        // Use the saved templateId
+        const templateld = (field as any).templateId as string;
+        const newFieldId = generateUniqueId(groupId, groupIndex, templateld);
+        newGroupItemState[newFieldId] = initialData?.[newFieldId] ?? "";
       });
 
       return {
@@ -717,22 +714,28 @@ const Renderer: React.FC<RendererProps> = ({ data, mode, goBack }) => {
 
 
     switch (item.type) {
-      case "text-input":
-        return (
-          <><InputMask
-            className="field-container no-print"
+      case "text-input": {
 
-            mask={item.mask || ''}
-            value={
-              groupId
-                ? groupStates[groupId]?.[groupIndex!]?.[fieldId] || ""
-                : formStates[fieldId] || ""
-            }
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              handleInputChange(fieldId, e.target.value, groupId, groupIndex, item)
-            }
-            readOnly={formData.readOnly || doesFieldHasCondition("readOnly", item, groupId, groupIndex) || calcValExists || mode == "view"}
+        const value = groupId
+        ? groupStates[groupId]?.[groupIndex!]?.[fieldId] || ""
+        : formStates[fieldId] || ""
+      
+        const onChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+          handleInputChange(fieldId, e.target.value, groupId, groupIndex, item);
+      
+        const readOnly = formData.readOnly || 
+          doesFieldHasCondition("readOnly", item, groupId, groupIndex) || 
+          calcValExists || 
+          mode === "view";
+      
+        const screenInput = item.mask ? (
+          <InputMask
+            className="field-container no-print"
+            mask={item.mask}
             {...item.attributes}
+            value={value}
+            onChange={onChange}
+            readOnly={readOnly}  
           >
             <Component
               className="field-container no-print"
@@ -750,23 +753,43 @@ const Renderer: React.FC<RendererProps> = ({ data, mode, goBack }) => {
               {...item.attributes}
             />
           </InputMask>
+        ) : (
+          <Component
+            className="field-container no-print"
+            key={fieldId}
+            id={fieldId}
+            {...item.attributes}
+            value={value}
+            onChange={onChange}
+            readOnly={readOnly}
+            labelText={label}
+            placeholder={item.placeholder}
+            helperText={item.helperText}
+            name={fieldId}
+            style={{                
+              ...(isPrinting ? item.pdfStyles : item.webStyles),
+            }}
+            invalid={!!error}
+            invalidText={error || ""}
+            
+          />
+        );  
+        return (
+          <>
+            {screenInput}
             <div className="hidden-on-screen field-wrapper-print" style={{
               ...(isPrinting ? item.pdfStyles : item.webStyles),
             }}>
               <div className="field_label-wrapper-print">
                 <label className="field-label-print"><span>{label}</span> </label>
               </div>
-
               <div className="field_value-wrapper-print">
-                {
-                  groupId
-                    ? groupStates[groupId]?.[groupIndex!]?.[fieldId] || ""
-                    : formStates[fieldId] || ""
-                }
+                {value}
               </div>
             </div>
           </>
         );
+      }    
       case "currency-input":
         return (
           <CurrencyInput


### PR DESCRIPTION
## What changes did you make?

Refactor group Id generation:
- stashing each field’s original ID in templateId before overwriting it, so every new group instance uses that stable base to generate its unique ID correctly rather than re-parsing an already-mutated ID.

Refactored text-input:
- Centralized the value/onChange/readOnly logic and conditionally render mask only if its present.

## Why did you make these changes?

Group Ids weren't getting correctly causing databinding issues. Text-input was not rendering values correctly so I streamlined it.

## What alternatives did you consider?

None.

### Checklist

- [X] **I have assigned at least one reviewer**
- [X] **My code has adequate test coverage (if applicable)**
