### PR TITLE
(ADO-3252) local workaround

### DIFF
--- a/src/Renderer.tsx
+++ b/src/Renderer.tsx
@@ -221,7 +221,7 @@ const Renderer: React.FC<RendererProps> = ({ data, mode, goBack }) => {
         script.id = scriptId;
         script.textContent = scriptContent;
         document.head.appendChild(script);
-      }, 1500);
+      }, 2000);
     }
 
     // Cleanup on unmount

--- a/src/Renderer.tsx
+++ b/src/Renderer.tsx
@@ -216,10 +216,12 @@ const Renderer: React.FC<RendererProps> = ({ data, mode, goBack }) => {
       document.head.appendChild(style);
     }
     if (scriptContent) {
-      const script = document.createElement('script');
-      script.id = scriptId;
-      script.textContent = scriptContent;
-      document.head.appendChild(script);
+      setTimeout(() => {
+        const script = document.createElement('script');
+        script.id = scriptId;
+        script.textContent = scriptContent;
+        document.head.appendChild(script);
+      }, 1500);
     }
 
     // Cleanup on unmount


### PR DESCRIPTION
## What changes did you make?

Added a setTimeout for 1.5 seconds around the create and add script tag for HTML.

## Why did you make these changes?

Doing this delays the script to be added to the HTML. This gives some time for the data binding values to load in and should allow them to appear as expected in "Show Letter" as well as console logging of javascript values.

Only issue is that this delay of script to be added can make script appear on first load (it will go away when setTimeout runs out)
<img width="865" height="491" alt="image" src="https://github.com/user-attachments/assets/a32e1436-c932-437b-a991-b3d6b72f1b59" />


## What alternatives did you consider?

This is currently just a workaround. Further testing is required to determine how to pause the script create/add so that it's guaranteed the data bindings have been loaded in

### Checklist

- [X] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
