### PR TITLE
ADO-3252 separate mode into style and script in renderer to fix non-pdf view

### DIFF
--- a/src/Renderer.tsx
+++ b/src/Renderer.tsx
@@ -193,9 +193,10 @@ const Renderer: React.FC<RendererProps> = ({ data, mode, goBack }) => {
   const pdfFormScript = getByType(scripts, 'pdf');
 
   useEffect(() => {
-    const mode = isPrinting ? 'pdf' : 'web';
-    const styleId = `${mode}-form-styles`;
-    const scriptId = `${mode}-form-script`;
+    const modeScript = isPrinting ? 'pdf' : 'web';
+    const modeStyle = (isPrinting && pdfStyleSheet != undefined) ? 'pdf' : 'web';
+    const styleId = `${modeStyle}-form-styles`;
+    const scriptId = `${modeScript}-form-script`;
 
     // Remove any existing style/script tags for both modes
     ['web', 'pdf'].forEach((m) => {


### PR DESCRIPTION
## What changes did you make?

Separate mode value in Renderer.tsx to consider styles and scripts instead of all in one.

## Why did you make these changes?

It is possible for PDF (aka print view) mode to not include styles. Doing so will remove all styles seen from web page. We need the web page styles to apply to print mode when there are no PDF styles listed.

## What alternatives did you consider?

Keeping mode as the all-in-one toggle for both scripts and styles. However, doing this would overwrite any form differences between PDF and web page as well to only use web page values. In case some fields are not required for print view, these need to be separate.

### Checklist

- [X] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
