### PR TITLE
Dev

### DIFF
--- a/src/Renderer.tsx
+++ b/src/Renderer.tsx
@@ -221,7 +221,7 @@ const Renderer: React.FC<RendererProps> = ({ data, mode, goBack }) => {
         script.id = scriptId;
         script.textContent = scriptContent;
         document.head.appendChild(script);
-      }, 1500);
+      }, 2000);
     }
 
     // Cleanup on unmount

--- a/src/Renderer.tsx
+++ b/src/Renderer.tsx
@@ -193,9 +193,10 @@ const Renderer: React.FC<RendererProps> = ({ data, mode, goBack }) => {
   const pdfFormScript = getByType(scripts, 'pdf');
 
   useEffect(() => {
-    const mode = isPrinting ? 'pdf' : 'web';
-    const styleId = `${mode}-form-styles`;
-    const scriptId = `${mode}-form-script`;
+    const modeScript = isPrinting ? 'pdf' : 'web';
+    const modeStyle = (isPrinting && pdfStyleSheet != undefined) ? 'pdf' : 'web';
+    const styleId = `${modeStyle}-form-styles`;
+    const scriptId = `${modeScript}-form-script`;
 
     // Remove any existing style/script tags for both modes
     ['web', 'pdf'].forEach((m) => {

--- a/src/Renderer.tsx
+++ b/src/Renderer.tsx
@@ -193,7 +193,7 @@ const Renderer: React.FC<RendererProps> = ({ data, mode, goBack }) => {
   const pdfFormScript = getByType(scripts, 'pdf');
 
   useEffect(() => {
-    const modeScript = isPrinting ? 'pdf' : 'web';
+    const modeScript = (isPrinting && pdfFormScript != undefined) ? 'pdf' : 'web';
     const modeStyle = (isPrinting && pdfStyleSheet != undefined) ? 'pdf' : 'web';
     const styleId = `${modeStyle}-form-styles`;
     const scriptId = `${modeScript}-form-script`;
@@ -207,8 +207,8 @@ const Renderer: React.FC<RendererProps> = ({ data, mode, goBack }) => {
     });
 
     // Add current mode's style/script if present
-    const styleContent = mode === 'pdf' ? pdfStyleSheet : webStyleSheet;
-    const scriptContent = mode === 'pdf' ? pdfFormScript : webFormScript;
+    const styleContent = modeStyle === 'pdf' ? pdfStyleSheet : webStyleSheet;
+    const scriptContent = modeScript === 'pdf' ? pdfFormScript : webFormScript;
 
     if (styleContent) {
       const style = document.createElement('style');

--- a/src/Renderer.tsx
+++ b/src/Renderer.tsx
@@ -216,10 +216,12 @@ const Renderer: React.FC<RendererProps> = ({ data, mode, goBack }) => {
       document.head.appendChild(style);
     }
     if (scriptContent) {
-      const script = document.createElement('script');
-      script.id = scriptId;
-      script.textContent = scriptContent;
-      document.head.appendChild(script);
+      setTimeout(() => {
+        const script = document.createElement('script');
+        script.id = scriptId;
+        script.textContent = scriptContent;
+        document.head.appendChild(script);
+      }, 1500);
     }
 
     // Cleanup on unmount


### PR DESCRIPTION
## What changes did you make?

- Added a setTimeout for 1.5 seconds around the create and add script tag for HTML.
- Separate mode value in Renderer.tsx to consider styles and scripts instead of all in one.
- Missing change from mode to new values
- Check if PDF script is undefined and use web script if so

## Why did you make these changes?

- Doing this delays the script to be added to the HTML. This gives some time for the data binding values to load in and should allow them to appear as expected in "Show Letter" as well as console logging of javascript values.
- It is possible for PDF (aka print view) mode to not include styles and scripts. Doing so will remove all styles and scripts seen from web page. We need the web page styles and scripts to apply to print mode when there are no PDF styles listed.

## What alternatives did you consider?

See PRs 171, 172, and 173

### Checklist

- [X] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
