### PR TITLE
(ADO-3265 workaround) force script load on page when initialization is complete

### DIFF
--- a/src/Renderer.tsx
+++ b/src/Renderer.tsx
@@ -114,6 +114,7 @@ const Renderer: React.FC<RendererProps> = ({ data, mode, goBack }) => {
   const [modalTitle, setModalTitle] = useState("KILN");
   const [modalMessage, setModalMessage] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [isScriptRenderReady, setIsScriptRenderReady] = useState(false);
 
   // Create Initial field registration in external store
   const createFieldRegistrationWrapper = (fieldId: string, groupId?: string, groupIndex?: number) => {
@@ -216,13 +217,11 @@ const Renderer: React.FC<RendererProps> = ({ data, mode, goBack }) => {
       style.textContent = styleContent;
       document.head.appendChild(style);
     }
-    if (scriptContent) {
-      setTimeout(() => {
-        const script = document.createElement('script');
-        script.id = scriptId;
-        script.textContent = scriptContent;
-        document.head.appendChild(script);
-      }, 2000);
+    if (scriptContent && isScriptRenderReady) {
+      const script = document.createElement('script');
+      script.id = scriptId;
+      script.textContent = scriptContent;
+      document.head.appendChild(script);
     }
 
     // Cleanup on unmount
@@ -232,7 +231,7 @@ const Renderer: React.FC<RendererProps> = ({ data, mode, goBack }) => {
       const script = document.getElementById(scriptId);
       if (script) script.remove();
     };
-  }, [isPrinting, webStyleSheet, pdfStyleSheet, webFormScript, pdfFormScript]);
+  }, [isPrinting, webStyleSheet, pdfStyleSheet, webFormScript, pdfFormScript, isScriptRenderReady]);
 
   //on close, execute unlock form
   useEffect(() => {
@@ -385,6 +384,7 @@ const Renderer: React.FC<RendererProps> = ({ data, mode, goBack }) => {
     setFormStates(initialFormStates);
     setGroupStates(initialGroupStates);
     setFormData(updatedFormData);
+    setIsScriptRenderReady(true);
   }, [data]);
 
 // Add a ref to track if fields are already registered


### PR DESCRIPTION
## What changes did you make?

const [isScriptRenderReady, setIsScriptRenderReady] = useState(false);

Added isScriptRenderReady to the useEffect for loading in script values.

Added setIsScriptRenderReady(true) to the end of useEffect for initialization.

Removed setTimeout workaround.

## Why did you make these changes?

The setTimeout did not work for longer loads and caused some confusion when pages did not render as expected on first glance. Using a value that updates one the initialization useEffect has finished allows it to force an update which add and uses the javascript

## What alternatives did you consider?

This is a workaround and will likely need further changes because it forces the render to go twice (once for the initial load, and a second time once initialization completes. This should be brought down to one render if possible)

### Checklist

- [X] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
