### PR TITLE
Pull interface from server, created portal actions

### DIFF
--- a/src/EditPortalFormPage.tsx
+++ b/src/EditPortalFormPage.tsx
@@ -38,6 +38,24 @@ const EditPortalFormPage: React.FC = () => {
     return match ? decodeURIComponent(match[1]) : null;
   }
 
+  async function fetchInterface(originalServer: string | null) {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      ...(originalServer ? { "X-Original-Server": originalServer } : {}),
+    };
+  
+    const resp = await fetch(API.interface, { method: "GET", headers });
+    if (!resp.ok) {
+      throw new Error(`Interface fetch failed: ${resp.status} ${await resp.text()}`);
+    }
+  
+    const payload = await resp.json();
+  
+    const buttons = Array.isArray(payload?.interface?.interface)? payload.interface.interface: [];
+  
+    sessionStorage.setItem("interface", JSON.stringify({ interface: buttons }));
+  }
+
   const handleLoadTemplate = async (params: { [key: string]: string | null }) => {
     setIsEditPageLoading(true);
 
@@ -59,10 +77,22 @@ const EditPortalFormPage: React.FC = () => {
       if (!response.ok) {
         const errorData = await response.json(); // Parse error response        
         throw new Error(errorData.error || "Something went wrong");
+      } 
+        
+      const result = await response.json();  
+      
+      if (Array.isArray(result?.interface?.interface)) {
+        sessionStorage.setItem("interface", JSON.stringify({ interface: result.interface.interface })
+        );
       } else {
-        const result = await response.json();        
-        setJsonContent(result);        
+        try {
+          await fetchInterface(originalServer);
+        } catch (error) {
+          console.warn("fetchInterface failed", error);
+        }
       }
+
+      setJsonContent(result);    
 
     } catch (error) {
       navigate("/error", { state: { message: error instanceof Error ? error.message : String(error) } }); // Pass error
@@ -76,7 +106,7 @@ const EditPortalFormPage: React.FC = () => {
   return (
     <>
       <LoadingOverlay isLoading={isEditPageLoading} message="Please wait while the form is being loaded." />
-      <Presenter data={jsonContent} mode="portal" />
+      <Presenter data={jsonContent} mode="portalEdit" />
     </>
   );
 };

--- a/src/NewPortalFormPage.tsx
+++ b/src/NewPortalFormPage.tsx
@@ -38,6 +38,24 @@ const NewPortalFormPage: React.FC = () => {
     return match ? decodeURIComponent(match[1]) : null;
   }
 
+  async function fetchInterface(originalServer: string | null) {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      ...(originalServer ? { "X-Original-Server": originalServer } : {}),
+    };
+  
+    const resp = await fetch(API.interface, { method: "GET", headers });
+    if (!resp.ok) {
+      throw new Error(`Interface fetch failed: ${resp.status} ${await resp.text()}`);
+    }
+  
+    const payload = await resp.json();
+  
+    const buttons = Array.isArray(payload?.interface?.interface)? payload.interface.interface: [];
+  
+    sessionStorage.setItem("interface", JSON.stringify({ interface: buttons }));
+  }
+
   const handleGenerateTemplate = async (params: { [key: string]: string | null }) => {
     setIsNewPageLoading(true);
 
@@ -61,6 +79,18 @@ const NewPortalFormPage: React.FC = () => {
         throw new Error(errorData.error || "Something went wrong");
       } else {
         const result = await response.json();
+
+        if (Array.isArray(result?.interface?.interface)) {
+          sessionStorage.setItem("interface", JSON.stringify({ interface: result.interface.interface })
+          );
+        } else {
+          try {
+            await fetchInterface(originalServer);
+          } catch (error) {
+            console.warn("fetchInterface failed", error);
+          }
+        }
+
         setJsonContent(result.save_data);        
       }
 
@@ -76,7 +106,7 @@ const NewPortalFormPage: React.FC = () => {
   return (
     <>
       <LoadingOverlay isLoading={isNewPageLoading} message="Please wait while the form is being loaded." />
-      <Presenter data={jsonContent} mode="portal" />
+      <Presenter data={jsonContent} mode="portalNew" />
     </>
   );
 };

--- a/src/Renderer.tsx
+++ b/src/Renderer.tsx
@@ -2200,6 +2200,7 @@ const handleRemoveGroupItem = (groupId: string, groupItemIndex: number) => {
         ...bodyFromAction,
         path: action?.path,
         headers: action?.headers,
+        type: action?.type,
       };
   
   

--- a/src/Renderer.tsx
+++ b/src/Renderer.tsx
@@ -2193,7 +2193,7 @@ const handleRemoveGroupItem = (groupId: string, groupItemIndex: number) => {
         ...(originalServer ? { "X-Original-Server": originalServer } : {}),
       };
   
-      const endpoint = eval(action.path);
+      const endpoint = eval(action.api_path);
       const bodyFromAction = eval(`(() => ({ ${action.body} }))()`);
 
       const body = {

--- a/src/Renderer.tsx
+++ b/src/Renderer.tsx
@@ -89,7 +89,8 @@ interface RendererProps {
   goBack?: () => void; // Add a goBack prop
 }
 
-
+const visibleForMode = (btn: any, activeMode: string) =>
+  !Array.isArray(btn.mode) || btn.mode.includes(activeMode);
 
 const Renderer: React.FC<RendererProps> = ({ data, mode, goBack }) => {
   const { store } = useExternalState();
@@ -115,6 +116,8 @@ const Renderer: React.FC<RendererProps> = ({ data, mode, goBack }) => {
   const [modalMessage, setModalMessage] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [isScriptRenderReady, setIsScriptRenderReady] = useState(false);
+  const [formInterface, setFormInterface] = useState<InterfaceElement[] | null>(null);
+
 
   // Create Initial field registration in external store
   const createFieldRegistrationWrapper = (fieldId: string, groupId?: string, groupIndex?: number) => {
@@ -739,6 +742,37 @@ const handleRemoveGroupItem = (groupId: string, groupItemIndex: number) => {
     });
   };
 
+  useEffect(() => {
+    // Prefer interface from formData
+    const fromFD = (formData as any)?.interface;
+    if (Array.isArray(fromFD) && fromFD.length > 0) {
+      setFormInterface(fromFD);
+      return;
+    }
+  
+    // Otherwise, try sessionStorage
+    const sessionInterface = sessionStorage.getItem("interface");
+    if (!sessionInterface) {
+      setFormInterface(null);
+      return;
+    }
+  
+    try {
+      const parsed = JSON.parse(sessionInterface);
+      setFormInterface(Array.isArray(parsed?.interface) ? parsed.interface : null);
+    } catch {
+      setFormInterface(null);
+    }
+  }, [formData]);
+  
+  
+
+  function getCookie(name: string): string | null {
+    const match = document.cookie.match(
+      new RegExp('(?:^|; )' + name.replace(/([.$?*|{}()[\]\\/+^])/g, '\\$1') + '=([^;]*)')
+    );
+    return match ? decodeURIComponent(match[1]) : null;
+  }
 
   /*
   Function to verify whether the state of the element should be included in savedJson or not.
@@ -2132,71 +2166,80 @@ const handleRemoveGroupItem = (groupId: string, groupItemIndex: number) => {
     }
   };
 
-  const onButtonClick =  async (buttonConfig: InterfaceElement)  => {
-    // This is your parent-level logic
-    console.log("Button clicked:", buttonConfig.label);
-    console.log("Current form data:", buttonConfig);
-    // Perhaps call the backend, show a notification, etc.
-   
-    setIsLoading(true); // Show loading overlay
-    setModalOpen(false); // Ensure modal is closed when a new request starts
+  const executeJavascriptAction = async (script?: string) => {
+    if (!script) return true;
     try {
-      if (validateAllFields()) {
-        const returnMessage =await submitForButtonAction(buttonConfig);
-        if ((returnMessage) === "success") {
-          setModalTitle("Success ✅");
-          setModalMessage("Form Saved Successfully.");
-        } else {
-          setModalTitle("Error ❌ ");
-          setModalMessage(returnMessage);
-        }
-        setModalOpen(true);
-      } else {
-        setModalTitle("Validation Error ❌ ");
-        setModalMessage("Error saving form. Please clear the errors in the form before saving.");
-        setModalOpen(true);
-      }
+      const wrapped = `(async () => { ${script} })()`;
+      const result = await eval(wrapped);
+      return result !== false;
     } catch (error) {
-      setModalTitle("Error ❌ ");
-      setModalMessage("Error saving form. Please try again.");
+      console.error("JavaScript action failed:", error);
+      setModalTitle("Error");
+      setModalMessage("Client script failed.");
       setModalOpen(true);
-    }
-    finally {
-      setIsLoading(false); // Hide loading overlay once request completes
+      return false;
     }
   };
 
-    const submitForButtonAction = async (buttonConfig: InterfaceElement) => {
+  const executeApiAction = async (action: any) => {
     try {
-      const submitForActionEndpoint = API.submitForButtonAction;
       const state = sessionStorage.getItem("formParams");
-      const params = state ? (JSON.parse(state) as Record<string,string>) : {};
-      const savedJson: Record<string, any> = {
-        "tokenId": params["id"],        
-        "savedForm": JSON.stringify(createSavedData()),
-        "config":buttonConfig
-      };      
-
-      const response = await fetch(submitForActionEndpoint, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(savedJson),
+      const params = state ? JSON.parse(state) as Record<string, string> : {};
+      const originalServer = getCookie("originalServer");
+      void params;
+  
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        ...(originalServer ? { "X-Original-Server": originalServer } : {}),
+      };
+  
+      const endpoint = eval(action.path);
+      const body = eval(`(() => ({ ${action.body} }))()`);
+  
+      const response = await fetch(endpoint, {
+        method: action.type,
+        headers,
+        body: JSON.stringify(body),
       });
-      if (response.ok) {
-        const result = await response.json();
-        console.log("Result ", result);
-        return "success";
-      } else {
-        const errorData = await response.json(); // Parse error response        
-        //throw new Error(errorData.error || "Something went wrong");
-        console.error("Error:",errorData.error);
-        return errorData?.error || "Error saving form. Please try again.";
+  
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        console.error("API error:", errorData?.error);
+        return false;
       }
+  
+      return true;
     } catch (error) {
-      console.error("Error:", error);
-      return "failed";
+      console.error("API action failed:", error);
+      return false;
+    }
+  };
+  
+  
+
+  const onButtonClick = async (buttonConfig: InterfaceElement) => {
+    const actions = (buttonConfig as any)?.actions || [];
+    if (!Array.isArray(actions) || actions.length === 0) return;
+  
+    setIsLoading(true);
+    setModalOpen(false); 
+    try {
+      for (const action of actions) {
+        if (action.action_type === "javascript") {
+          const succeeded = await executeJavascriptAction(action.script);
+          if (succeeded === false) break;
+        } else if (action.action_type === "endpoint") {
+          const succeeded = await executeApiAction(action);
+          if (!succeeded) break; 
+        } else {
+          setModalTitle("Error");
+          setModalMessage(`Unknown action type: ${String(action.action_type)}`);
+          setModalOpen(true);
+          break;
+        }
+      }
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -2296,6 +2339,9 @@ const handleRemoveGroupItem = (groupId: string, groupItemIndex: number) => {
                   <Button onClick={handleSaveAndClose} kind="secondary" className="no-print" id="saveAndClose">
                     Save And Close
                   </Button>
+                  <Button kind="secondary" onClick={handlePrint} className="no-print">
+                Print
+              </Button>
 
                 </>
               )}
@@ -2303,7 +2349,17 @@ const handleRemoveGroupItem = (groupId: string, groupItemIndex: number) => {
                 <>
                   <Button onClick={handleGenerate} kind="secondary" className="no-print" id="generate">
                     Generate
-                  </Button>                  
+                  </Button>    
+                  <Button kind="secondary" onClick={handlePrint} className="no-print">
+                Print
+              </Button>              
+                </>
+              )}
+              {mode == "view" && (
+                <>        
+                  <Button kind="secondary" onClick={handlePrint} className="no-print">
+                      Print
+                  </Button>       
                 </>
               )}
               {(mode == "previewPortal") && (
@@ -2317,27 +2373,55 @@ const handleRemoveGroupItem = (groupId: string, groupItemIndex: number) => {
               </>
             )}
 
-              {(mode == "portal" || goBack)  && formData.interface && (
-              <div className="header-buttons-only no-print"> 
-                {formData.interface?.map((btn: any, idx: any) => (
-                  <ButtonRenderer
-                      key={idx}
-                      config={btn}
-                      onButtonClick={onButtonClick}
-                      disabled={typeof goBack === 'function'}   // Now matches single-arg signature
-                    />
-                ))}      
-              </div>
-            )}
+            {(mode === "portalNew" || goBack) && formInterface && (
+                <div className="header-buttons-only no-print">
+                  {formInterface
+                    .filter((btn: any) => visibleForMode(btn, mode))
+                    .map((btn: InterfaceElement, idx: number) => (
+                      <ButtonRenderer
+                        key={idx}
+                        config={btn}
+                        onButtonClick={onButtonClick}
+                        disabled={typeof goBack === "function"}
+                      />
+                    ))}
+                </div>
+              )}
+            
+            {(mode === "portalEdit" || goBack) && formInterface && (
+                <div className="header-buttons-only no-print">
+                  {formInterface
+                    .filter((btn: any) => visibleForMode(btn, mode))
+                    .map((btn: InterfaceElement, idx: number) => (
+                      <ButtonRenderer
+                        key={idx}
+                        config={btn}
+                        onButtonClick={onButtonClick}
+                        disabled={typeof goBack === "function"}
+                      />
+                    ))}
+                </div>
+              )}
+              {(mode === "portalView" || goBack) && formInterface && (
+                <div className="header-buttons-only no-print">
+                  {formInterface
+                    .filter((btn: any) => visibleForMode(btn, mode))
+                    .map((btn: InterfaceElement, idx: number) => (
+                      <ButtonRenderer
+                        key={idx}
+                        config={btn}
+                        onButtonClick={onButtonClick}
+                        disabled={typeof goBack === "function"}
+                      />
+                    ))}
+                </div>
+              )}
               {goBack && (
                 <Button onClick={goBack} kind="secondary" className="no-print">
                   Back
                 </Button>
               )}
               
-              <Button kind="secondary" onClick={handlePrint} className="no-print">
-                Print
-              </Button>
             </div>
             <div className="form-title hidden-on-screen">
               <div className="header-form-id-print ">{formData.form_id}</div>

--- a/src/Renderer.tsx
+++ b/src/Renderer.tsx
@@ -2194,7 +2194,14 @@ const handleRemoveGroupItem = (groupId: string, groupItemIndex: number) => {
       };
   
       const endpoint = eval(action.path);
-      const body = eval(`(() => ({ ${action.body} }))()`);
+      const bodyFromAction = eval(`(() => ({ ${action.body} }))()`);
+
+      const body = {
+        ...bodyFromAction,
+        path: action?.path,
+        headers: action?.headers,
+      };
+  
   
       const response = await fetch(endpoint, {
         method: action.type,

--- a/src/ViewPortalFormPage.tsx
+++ b/src/ViewPortalFormPage.tsx
@@ -38,6 +38,24 @@ const ViewPortalFormPage: React.FC = () => {
     return match ? decodeURIComponent(match[1]) : null;
   }
 
+  async function fetchInterface(originalServer: string | null) {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      ...(originalServer ? { "X-Original-Server": originalServer } : {}),
+    };
+  
+    const resp = await fetch(API.interface, { method: "GET", headers });
+    if (!resp.ok) {
+      throw new Error(`Interface fetch failed: ${resp.status} ${await resp.text()}`);
+    }
+  
+    const payload = await resp.json();
+  
+    const buttons = Array.isArray(payload?.interface?.interface)? payload.interface.interface: [];
+  
+    sessionStorage.setItem("interface", JSON.stringify({ interface: buttons }));
+  }
+
   const handleLoadTemplate = async (params: { [key: string]: string | null }) => {
     setIsViewPageLoading(true);
 
@@ -60,7 +78,19 @@ const ViewPortalFormPage: React.FC = () => {
         const errorData = await response.json(); // Parse error response        
         throw new Error(errorData.error || "Something went wrong");
       } else {
-        const result = await response.json();        
+        const result = await response.json();       
+        
+        if (Array.isArray(result?.interface?.interface)) {
+          sessionStorage.setItem("interface", JSON.stringify({ interface: result.interface.interface })
+          );
+        } else {
+          try {
+            await fetchInterface(originalServer);
+          } catch (error) {
+            console.warn("fetchInterface failed", error);
+          }
+        }
+        
         setJsonContent(result);        
       }
 
@@ -76,7 +106,7 @@ const ViewPortalFormPage: React.FC = () => {
   return (
     <>
       <LoadingOverlay isLoading={isViewPageLoading} message="Please wait while the form is being loaded." />
-      <Presenter data={jsonContent} mode="view" />
+      <Presenter data={jsonContent} mode="portalView" />
     </>
   );
 };

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -27,8 +27,11 @@ export const API = {
   pdfTemplate:  getApiUrl("/pdfRender", import.meta.env.VITE_COMM_API_PDFTEMPLATE_ENDPOINT_URL),
   generatePortalForm: getApiUrl("/generatePortalForm", import.meta.env.VITE_COMM_API_GENERATE_PORTAL_FORM_ENDPOINT_URL),
   generateStandalone: getApiUrl("/generateStandalone", import.meta.env.VITE_COMM_API_GENERATE_STANDALONE_ENDPOINT_URL),  
-  submitForButtonAction: getApiUrl("/submitForPortalAction", import.meta.env.VITE_COMM_API_SUBMIT_TO_ACTION_ENDPOINT_URL),
+  saveButtonAction: getApiUrl("/saveForPortalAction", import.meta.env.VITE_COMM_API_SUBMIT_TO_ACTION_ENDPOINT_URL),
   loadPortalForm: getApiUrl("/loadPortalForm", import.meta.env.VITE_COMM_API_LOAD_PORTAL_FORM_ENDPOINT_URL),
+  interface: getApiUrl("/interface", import.meta.env.VITE_COMM_API_INTERFACE_URL),
+  submitButtonAction: getApiUrl("/submitForPortalAction", import.meta.env.VITE_COMM_API_SUBMIT_NET_PORTAL_URL),
+  cancelButtonAction: getApiUrl("/cancelForPortalAction", import.meta.env.VITE_COMM_API_CANCEL_NET_PORTAL_URL),
   getFormById: `${getKlammApiBaseUrl()}/api/form-versions/`,
   getFormKlammURL: `${getKlammApiBaseUrl()}/forms/form-versions/`,
 };


### PR DESCRIPTION
## What changes did you make?

**Interfaces**
Fetch interface from the Communication Layer when no interface is present in a form definition for a portal form. This interface is stored in session storage to ensure it does not get added to the form definition. The buttons defined in the interface are filtered based on what view they are in.

**Actions**
When a button is clicked the actions associated with that button are executed. There are two action types, JavaScript and Endpoint. The JavaScript action executes a code block of JavaScript. While a Endpoint action calls an API endpoint, executed based on the action type and with some parameters defined in its body.

## Why did you make these changes?

Allows for interfaces to be defined on a per server basis rather than on a per form basis. Actions need to be executed on the Kiln side since JavaScript code references functions in the renderer. 

## What alternatives did you consider?

None.

### Checklist

- [X] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
